### PR TITLE
Derive on structs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,15 @@ use num_integer::Integer;
 use num_traits::{PrimInt, Unsigned, WrappingShr};
 use std::convert::TryInto;
 
-#[repr(C, packed)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[repr(C)]
 pub struct Divider<T: PrimInt> {
     magic: T,
     more: u8,
 }
 
-#[repr(C, packed)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[repr(C)]
 pub struct BranchFreeDivider<T> {
     magic: T,
     more: u8,


### PR DESCRIPTION
Also, the `repr(packed)` makes no sense here. Even if the struct is small, it'd have padding to satisfy its alignment anyway in all cases where packed would actually do anything.